### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,9 @@ on:
         required: true
         default: '1.0.0'
 
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: macos-latest


### PR DESCRIPTION
Potential fix for [https://github.com/mherrera53/GitMac/security/code-scanning/1](https://github.com/mherrera53/GitMac/security/code-scanning/1)

To fix the problem, add an explicit `permissions:` block that grants only the minimal scopes the workflow actually needs. This can be done at the workflow root (applies to all jobs) or per job. Here we have a single job (`build`), so adding it at the root is simple and clear.

Concretely:

- The job needs to read repository contents for `actions/checkout` → `contents: read`.
- It needs to create or update GitHub Releases via `softprops/action-gh-release` and to upload associated assets, which uses the Releases/Contents API → `contents: write` is required for publishing release assets and editing release descriptions.
- It does not interact with issues, PRs, workflows, or other resources, so those permissions can remain at their implicit default of `none`.

The minimal change is to insert:

```yaml
permissions:
  contents: write
```

near the top of the workflow, e.g. after the `on:` block and before `jobs:`. This leaves existing behavior unchanged while constraining the `GITHUB_TOKEN` to only repository contents write access, which is what a release job typically needs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
