### PR TITLE
fix: CI workflows pointing to 'main' instead of 'master'

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,9 +2,9 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "master" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "master" ]
   schedule:
     - cron: '0 0 * * 1'  # Run weekly on Mondays
 
@@ -48,6 +48,7 @@ jobs:
         xcodebuild -project GitMac.xcodeproj \
           -scheme GitMac \
           -destination 'platform=macOS' \
+          -skipPackagePluginValidation \
           -configuration Release \
           clean build \
           CODE_SIGN_IDENTITY="-" \

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -6,9 +6,9 @@ permissions:
 
 on:
   push:
-    branches: ["main"]
+    branches: ["master"]
   pull_request:
-    branches: ["main"]
+    branches: ["master"]
 
 jobs:
   build:


### PR DESCRIPTION
- codeql.yml: branches main→master, add -skipPackagePluginValidation
- swift.yml: branches main→master